### PR TITLE
Fixed compile error and warnings

### DIFF
--- a/src/ESP_OTA_GitHub.cpp
+++ b/src/ESP_OTA_GitHub.cpp
@@ -175,7 +175,6 @@ bool ESPOTAGitHub::checkUpgrade() {
 	if (!error) {
 		if (doc.containsKey("tag_name")) {
 			const char* release_tag = doc["tag_name"];
-            const char* release_name = doc["name"];
             bool release_prerelease = doc["prerelease"];
 			if (strcmp(release_tag, _currentTag) != 0) {
 				if (!_preRelease) {
@@ -259,6 +258,8 @@ bool ESPOTAGitHub::doUpgrade() {
             _lastError = "HTTP_UPDATE_OK";
             return true;
     }
+    _lastError = "UNEXPECTED RETURN CODE";
+    return false;
 }
 
 String ESPOTAGitHub::getLastError() {

--- a/src/ESP_OTA_GitHub.cpp
+++ b/src/ESP_OTA_GitHub.cpp
@@ -175,6 +175,7 @@ bool ESPOTAGitHub::checkUpgrade() {
 	if (!error) {
 		if (doc.containsKey("tag_name")) {
 			const char* release_tag = doc["tag_name"];
+            // const char* release_name = doc["name"];
             bool release_prerelease = doc["prerelease"];
 			if (strcmp(release_tag, _currentTag) != 0) {
 				if (!_preRelease) {

--- a/src/ESP_OTA_GitHub.h
+++ b/src/ESP_OTA_GitHub.h
@@ -23,7 +23,7 @@
 #define GHOTA_NTP1 "pool.ntp.org"
 #define GHOTA_NTP2 "time.nist.gov"
 
-typedef struct urlDetails_t {
+struct urlDetails_t {
     String proto;
     String host;
 	int port;


### PR DESCRIPTION
Fixes for the following errors and warnings I got with recent platformio:
```
In file included from src/esp8266_ota.cpp:4:
.pio/libdeps/d1_mini_lite/ESP OTA GitHub/src/ESP_OTA_GitHub.h:26:1: warning: 'typedef' was ignored in this declaration
   26 | typedef struct urlDetails_t {
```

```
.pio/libdeps/d1_mini_lite/ESP OTA GitHub/src/ESP_OTA_GitHub.cpp: In member function 'bool ESPOTAGitHub::checkUpgrade()':
.pio/libdeps/d1_mini_lite/ESP OTA GitHub/src/ESP_OTA_GitHub.cpp:178:25: warning: unused variable 'release_name' [-Wunused-variable]
  178 |             const char* release_name = doc["name"];
```

```
.pio/libdeps/d1_mini_lite/ESP OTA GitHub/src/ESP_OTA_GitHub.cpp: In member function 'bool ESPOTAGitHub::doUpgrade()':
.pio/libdeps/d1_mini_lite/ESP OTA GitHub/src/ESP_OTA_GitHub.cpp:237:52: error: control reaches end of non-void function [-Werror=return-type]
  237 |     urlDetails_t splitURL = _urlDetails(_upgradeURL);
```

The last one is an error which makes the build fail so it would be nice if this could at least be fixed.