### PR TITLE
- added option to set memory for json object

### DIFF
--- a/src/ESP_OTA_GitHub.h
+++ b/src/ESP_OTA_GitHub.h
@@ -23,7 +23,7 @@
 #define GHOTA_NTP1 "pool.ntp.org"
 #define GHOTA_NTP2 "time.nist.gov"
 
-typedef struct urlDetails_t {
+struct urlDetails_t {
     String proto;
     String host;
 	int port;
@@ -32,7 +32,7 @@ typedef struct urlDetails_t {
 
 class ESPOTAGitHub {
 	public:
-		ESPOTAGitHub(BearSSL::CertStore* certStore, const char* user, const char* repo, const char* currentTag, const char* binFile, bool preRelease);
+		ESPOTAGitHub(BearSSL::CertStore* certStore, const char* user, const char* repo, const char* currentTag, const char* binFile, bool preRelease, size_t jsonCapacity = 0);
 		bool checkUpgrade();
 		bool doUpgrade();
 		String getLastError();
@@ -44,12 +44,13 @@ class ESPOTAGitHub {
 		
 		BearSSL::CertStore* _certStore;
 		String _lastError; // Holds the last error generated
-		String _upgradeURL; // Holds the upgrade URL (changes when _resolveRedirects() is run).
+		String _upgradeURL; // Holds the upgrade URL (changes when getFinalURL() is run).
 		const char* _user;
 		const char* _repo;
 		const char* _currentTag;
 		const char* _binFile;
 		bool _preRelease;
+		size_t _jsonCapacity;
 };
 
 #endif


### PR DESCRIPTION
I had issues with default setting of json capacity because my project was too memory greedy. I checked default json capacity and it was twice as much as I needed when checking my own repository json with [ArduinoJson Assistant](https://arduinojson.org/v6/assistant/). So I decided to add another attribute to constructor with default value set as it was with an option to use my own.